### PR TITLE
Include Cloud Native Definition

### DIFF
--- a/cloud-native.md
+++ b/cloud-native.md
@@ -6,4 +6,4 @@ These techniques enable loosely coupled systems that are resilient, manageable, 
 
 The Cloud Native Computing Foundation seeks to drive adoption of this paradigm by fostering and sustaining an ecosystem of open source, vendor-neutral projects. We democratize state-of-the-art patterns to make these innovations accessible for everyone.
 
-* official reference: [Cloud Native Definition](https://github.com/cncf/toc/blob/master/DEFINITION.md)
+* official reference: [Cloud Native Definition v1](https://github.com/cncf/toc/blob/master/DEFINITION.md)

--- a/cloud-native.md
+++ b/cloud-native.md
@@ -1,0 +1,9 @@
+# Cloud Native
+
+Cloud native technologies empower organizations to build and run scalable applications in modern, dynamic environments such as public, private, and hybrid clouds. Containers, service meshes, microservices, immutable infrastructure, and declarative APIs exemplify this approach.
+
+These techniques enable loosely coupled systems that are resilient, manageable, and observable. Combined with robust automation, they allow engineers to make high-impact changes frequently and predictably with minimal toil.
+
+The Cloud Native Computing Foundation seeks to drive adoption of this paradigm by fostering and sustaining an ecosystem of open source, vendor-neutral projects. We democratize state-of-the-art patterns to make these innovations accessible for everyone.
+
+* official reference: [Cloud Native Definition](https://github.com/cncf/toc/blob/master/DEFINITION.md)


### PR DESCRIPTION
Hi there,

I'm just adding the **Cloud Native Definition** from [CNCF Github's](https://github.com/cncf/toc/blob/master/DEFINITION.md)